### PR TITLE
Fix git reset

### DIFF
--- a/scripts/001-pkgconf.sh
+++ b/scripts/001-pkgconf.sh
@@ -8,7 +8,7 @@ BRANCH_NAME="pkgconf-1.8.0"
 if test ! -d "$REPO_FOLDER"; then
 	git clone --depth 1 -b $BRANCH_NAME $REPO_URL && cd $REPO_FOLDER || { exit 1; }
 else
-	cd $REPO_FOLDER && git fetch origin && git reset --hard origin/${BRANCH_NAME} || { exit 1; }
+	cd $REPO_FOLDER && git fetch origin && git reset --hard ${BRANCH_NAME} || { exit 1; }
 fi
 
 TARGET="psp"


### PR DESCRIPTION
https://github.com/pkgconf/pkgconf uses tags instead of branches, reseting returns 
"fatal: ambiguous argument 'origin/pkgconf-1.8.0': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'" when folder already exists.