### PR TITLE
Create a symlink to psp-pkgconf for compatability

### DIFF
--- a/scripts/002-psp-pkg-config.sh
+++ b/scripts/002-psp-pkg-config.sh
@@ -2,5 +2,6 @@
 
 mkdir -p "${PSPDEV}/bin"
 install -m755 ../patches/psp-pkg-config "${PSPDEV}/bin" || { exit 1; }
+ln -srf "${PSPDEV}/bin/psp-pkg-config" "${PSPDEV}/bin/psp-pkgconf"
 echo "psp-pkg-config installation finished"
 


### PR DESCRIPTION
This binary missing is causing opentri and sdl-ttf to not build.