### PR TITLE
Don't use -r flag when linking psp-pkgconf

### DIFF
--- a/scripts/002-psp-pkg-config.sh
+++ b/scripts/002-psp-pkg-config.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-WORKDIR="${PWD}"
 
 mkdir -p "${PSPDEV}/bin"
 install -m755 ../patches/psp-pkg-config "${PSPDEV}/bin" || { exit 1; }

--- a/scripts/002-psp-pkg-config.sh
+++ b/scripts/002-psp-pkg-config.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
+WORKDIR="${PWD}"
 
 mkdir -p "${PSPDEV}/bin"
 install -m755 ../patches/psp-pkg-config "${PSPDEV}/bin" || { exit 1; }
-ln -srf "${PSPDEV}/bin/psp-pkg-config" "${PSPDEV}/bin/psp-pkgconf"
+cd "${PSPDEV}/bin"
+ln -sf "psp-pkg-config" "psp-pkgconf"
 echo "psp-pkg-config installation finished"
-

--- a/scripts/002-psp-pkg-config.sh
+++ b/scripts/002-psp-pkg-config.sh
@@ -3,5 +3,5 @@
 mkdir -p "${PSPDEV}/bin"
 install -m755 ../patches/psp-pkg-config "${PSPDEV}/bin" || { exit 1; }
 cd "${PSPDEV}/bin"
-ln -sf "psp-pkg-config" "psp-pkgconf"
+ln -sf "psp-pkg-config" "psp-pkgconf" || { exit 1; }
 echo "psp-pkg-config installation finished"


### PR DESCRIPTION
Alpine Linux does not support it. This was causing the link to not be there when building psp-packages.