### PR TITLE
Workflow: Enable nightly deployment of Docker container

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,8 @@ on:
       - main
     tags:
       - v*
+  schedule:
+      - cron: 0 7 * * *
   repository_dispatch:
     types: [run_build]
 


### PR DESCRIPTION
Part of a series of PRs that ensure package versioning inconsistencies are not present inside of the `pspdev` Docker container due to being updated on a per-commit basis.