### PR TITLE
Do not build daily

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,8 +6,6 @@ on:
       - main
     tags:
       - v*
-  schedule:
-      - cron: 0 7 * * *
   repository_dispatch:
     types: [run_build]
 


### PR DESCRIPTION
This will not be needed with the changes to psptoolchain-allegrex. That will make trigger this build once per week.