### PR TITLE
Always pass PSPDEV to pkg-config

### DIFF
--- a/patches/psp-pkg-config
+++ b/patches/psp-pkg-config
@@ -11,5 +11,4 @@ export PKG_CONFIG_SYSROOT_DIR=
 export PKG_CONFIG_LIBDIR=${PSPDEV}/psp/lib/pkgconfig:${PSPDEV}/psp/share/pkgconfig
 
 [[ "$1" == '--version' ]] && exec pkg-config --version
-exec pkg-config --define-prefix --static "$@"
-
+exec pkg-config --define-prefix --define-variable=PSPDEV=${PSPDEV} --static "$@"


### PR DESCRIPTION
I just saw this error:
```
wouter@wouter-gridscale:~/Personal/oceanpop/psp$ psp-pkg-config --libs SDL2_image
Variable 'PSPDEV' not defined in '/home/wouter/Personal/pspdev/psp/lib/pkgconfig/libjpeg.pc'
```

This PR fixes this on this particular machine.