### PR TITLE
Link pacman against libcurl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV PATH $PATH:${PSPDEV}/bin
 
 COPY . /src
 
-RUN apk add build-base bash git autoconf automake python3 py3-pip cmake pkgconfig libarchive-dev openssl-dev gpgme-dev libtool
+RUN apk add build-base bash git autoconf automake python3 py3-pip cmake pkgconfig libarchive-dev openssl-dev gpgme-dev libtool curl-dev
 RUN cd /src && ./build-all.sh
 
 # Second stage of Dockerfile


### PR DESCRIPTION
As mentioned in https://github.com/pspdev/psp-pacman/issues/20, libcurl-dev needs to be installed prior to building pacman. Fixing it.