### PR TITLE
bugfix: on macos libtoolize is called glibtoolize

### DIFF
--- a/depends/check-dependencies.sh
+++ b/depends/check-dependencies.sh
@@ -78,7 +78,11 @@ check_program   cmake
 check_program   gcc
 check_program   g++
 
-check_program   libtoolize
+if [ "$(uname)" != "Darwin" ]; then
+check_program libtoolize
+else
+check_program glibtoolize
+fi 
 
 if [ ${#missing_depends[@]} -ne 0 ]; then
     echo "Couldn't find dependencies:"


### PR DESCRIPTION
The build on macos is failing because libtoolize doesn't exist because is called glibtoolize
