### PR TITLE
Build amd64 MacOS build on macos-15-intel

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         os: [
           [macos-latest, arm64, bash],
-          [macos-13, x86_64, bash],
+          [macos-15-intel, x86_64, bash],
           [ubuntu-latest, x86_64, bash]
         ]
       fail-fast: false


### PR DESCRIPTION
This fixes the build issues and speeds up the build. I'll have to do this for all repos unfortunately.