### PR TITLE
Add missing dependencies for new pacman

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -13,16 +13,17 @@ jobs:
     strategy:
       matrix:
         os: [[alpine, bash], [fedora, bash]]
+      fail-fast: false
     steps:
     - name: Install dependencies Alpine
       if: matrix.os[0] == 'alpine'
       run: |
-        apk add --no-cache build-base bash git autoconf automake python3 py3-pip cmake pkgconfig libarchive-dev openssl-dev gpgme-dev libtool
+        apk add --no-cache build-base bash git autoconf automake meson ninja-build pacman cmake pkgconfig libarchive-dev openssl-dev gpgme-dev libtool
     
     - name: Install dependencies Fedora
       if: matrix.os[0] == 'fedora'
       run: |
-        dnf -y install @development-tools g++ wget xz git autoconf automake python3 python3-pip cmake pkgconf libarchive-devel openssl-devel gpgme-devel libtool
+        dnf -y install @development-tools g++ wget xz git autoconf automake meson ninja-build makepkg cmake pkgconf libarchive-devel openssl-devel gpgme-devel libtool
 
     - uses: actions/checkout@v4
 
@@ -54,13 +55,13 @@ jobs:
       if: matrix.os[0] == 'ubuntu-latest'
       run: |
         sudo apt-get update
-        sudo apt-get -y install libcurl4 libcurl4-openssl-dev libssl-dev libarchive-dev libgpgme-dev
+        sudo apt-get -y install libcurl4 libcurl4-openssl-dev libssl-dev libarchive-dev libgpgme-dev meson makepkg
 
     - name: Install Dependencies Mac
       if: startsWith( matrix.os[0], 'macos' )
       run: |
         brew update
-        brew install automake bash openssl libarchive gpgme libtool
+        brew install automake bash openssl libarchive gpgme libtool meson makepkg
         brew reinstall openssl@3 # https://github.com/Homebrew/homebrew-core/issues/169728#issuecomment-2074958306
 
     - name: Compile Tools

--- a/depends/check-dependencies.sh
+++ b/depends/check-dependencies.sh
@@ -65,8 +65,9 @@ check_program   automake
 
 # Disabled pacman for windows
 if [ "${OSVER:0:5}" != MINGW ]; then
-check_program   python3
-check_program   pip3
+check_program   meson
+check_program   ninja
+check_program   makepkg
 check_program   gpgrt-config
 # check_program   gpgme-config
 check_header    openssl             openssl/crypto.h openssl/include/openssl/crypto.h


### PR DESCRIPTION
I changed how psp-pacman is build, so the dependencies need to be updated for the automated build  to work. I'm working on another change which will require makepkg to be installed as well.